### PR TITLE
convert to through2

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Wrap the output of a stream with a prefix and/or suffix.
 
+Streams2 compliant.
+
 ## Usage ##
 
 [![wrap-stream](https://nodei.co/npm/wrap-stream.png?mini=true)](https://nodei.co/npm/wrap-stream)

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var through = require('through')
+var through = require('through2')
 
 module.exports = wrap
 
@@ -9,17 +9,18 @@ function wrap(pre, post) {
 
   return through(write, end)
 
-  function write(data) {
+  function write(data, enc, cb) {
     if (first) {
-      if (send_pre) this.queue(pre)
+      if (send_pre) this.push(pre)
       first = false
     }
 
-    this.queue(data)
+    this.push(data)
+    cb()
   }
 
   function end() {
-    if (send_post) this.queue(post)
-    this.queue(null)
+    if (send_post) this.push(post)
+    this.push(null)
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "wrap-stream",
   "description": "Wrap the output of a stream with a prefix and/or suffix",
-  "version": "0.0.0",
+  "version": "2.0.0",
   "main": "index.js",
   "browser": "index.js",
   "dependencies": {
-    "through": "~2.3.4"
+    "through2": "^0.4.2"
   },
   "devDependencies": {
     "tape": "~1.1.1",
@@ -15,6 +15,7 @@
     "test": "node test"
   },
   "author": "Hugh Kennedy <hughskennedy@gmail.com> (http://github.com/hughsk)",
+  "contributors": "jden <jason@denizac.org",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/test.js
+++ b/test.js
@@ -9,6 +9,7 @@ test('pre and post work as expected', function(t) {
   fs.createReadStream(__dirname + '/index.js')
     .pipe(wrap('hello', 'world'))
     .pipe(concat(function(data) {
+      data = data.toString()
       t.ok(data.slice(0, 5) === 'hello', '"pre" works')
       t.ok(data.slice(-5) === 'world', '"post" works')
     }))


### PR DESCRIPTION
- updated implementation
- updated tests (streams2 prefers handling text streams as encoded buffers unless the stream is in object mode)
- updated version number in package.json. `2.0.0` was chosen to align with streams2.
  see #1
